### PR TITLE
Remove Prometheus exporter variant from MetricExporterKind enum

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -38,8 +38,6 @@ pub enum MetricExporterKind {
     Stdout,
     /// Export metrics using OpenTelemetry Protocol over gRPC
     OtlpGrpc,
-    /// Expose metrics in Prometheus format via HTTP endpoint
-    Prometheus,
 }
 
 impl FromStr for MetricExporterKind {
@@ -59,7 +57,6 @@ impl FromStr for MetricExporterKind {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "otlp" | "otlp-grpc" | "grpc" => Ok(MetricExporterKind::OtlpGrpc),
-            "prom" | "prometheus" => Ok(MetricExporterKind::Prometheus),
             _ => Ok(MetricExporterKind::Stdout),
         }
     }


### PR DESCRIPTION
 
This pull request removes support for the Prometheus metrics exporter from the `MetricExporterKind` enum and its associated functionality in the `from_str` implementation. 

### Removal of Prometheus metrics exporter:

* [`src/metrics.rs`](diffhunk://#diff-9f90e93b5696724fd8e4407c9db0bfd381d5468bcfbf2f09c17ac8510a85e104L41-L42): Removed the `Prometheus` variant from the `MetricExporterKind` enum, which was previously used to expose metrics in Prometheus format via an HTTP endpoint.
* [`src/metrics.rs`](diffhunk://#diff-9f90e93b5696724fd8e4407c9db0bfd381d5468bcfbf2f09c17ac8510a85e104L62): Updated the `from_str` implementation for `MetricExporterKind` to remove the handling of `"prom"` and `"prometheus"` strings, which previously mapped to the `Prometheus` variant.